### PR TITLE
隐私防护和使用便利性加强

### DIFF
--- a/install_v2ray.sh
+++ b/install_v2ray.sh
@@ -902,8 +902,8 @@ Type=simple
 # This service runs as root. You may consider to run it as another user for security concerns.
 # By uncommenting User=nobody and commenting out User=root, the service will run as user nobody.
 # More discussion at https://github.com/v2ray/v2ray-core/issues/1011
-User=root
-#User=nobody
+# User=root
+User=nobody
 NoNewPrivileges=true
 ExecStart=/usr/bin/v2ray/v2ray $v2ray_start_config /etc/v2ray/config.json
 Restart=on-failure

--- a/install_v2ray.sh
+++ b/install_v2ray.sh
@@ -1966,3 +1966,11 @@ case "$action" in
         echo " 用法: `basename $0` [menu|update|uninstall|start|restart|stop|showInfo|showLog]"
         ;;
 esac
+
+# Continue until user wish exit
+while true
+do
+	read -p "请按下回车键继续"
+    menu
+done
+

--- a/install_v2ray.sh
+++ b/install_v2ray.sh
@@ -721,6 +721,9 @@ server {
     $ROBOT_CONFIG
 
     location ${WSPATH} {
+      # Privacy: Do Not Log Proxy Access
+      access_log off;
+
       proxy_redirect off;
       proxy_pass http://127.0.0.1:${V2PORT};
       proxy_http_version 1.1;
@@ -728,8 +731,8 @@ server {
       proxy_set_header Connection "upgrade";
       proxy_set_header Host \$host;
       # Show real IP in v2ray access.log
-      proxy_set_header X-Real-IP \$remote_addr;
-      proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+      #proxy_set_header X-Real-IP \$remote_addr;
+      #proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
     }
 }
 EOF


### PR DESCRIPTION
目前Nginx 和 V2ray 都会记录服务器访问过的历史。为避免服务器被审计时日志暴露用户隐私和访问历史，此变更包含以下调整：

1. Nginx 不记录客户端使用代理时的IP地址。仍然记录哪些IP 访问过非代理路径，可结合Fail2Ban对爬虫做自动拦截。因不再记录代理客户端IP，调整配置使得Nginx 不转发代理客户端IP地址给上游。
3. 修改V2ray Service，不再向journald 打印访问的域名历史。
4. 保留V2ray 错误日志的记录功能，并配置日志轮转机制，只保留最小量错误日志。经过测试，在一般情况下不会有用户访问行为被记录。 
5. 调整主程序日志查看逻辑，替换journalctl 的方式，调整为tail -f 。
6. 由于环境检查耗时较久。补充主程序逻辑，执行完命令后不直接退出，以方便用户查看和尝试其他配置。用户可通过输入 0 或 Ctrl C 退出。